### PR TITLE
Facebook SDK not initialized when facebook app Id is falsy and retrieving the id from meta tag as fallback

### DIFF
--- a/src/js/share.js
+++ b/src/js/share.js
@@ -384,19 +384,21 @@ function ShareBar(options) {
         },
 
         getFacebookUi: function getFacebookUi() {
-            var facebookAppId = this.facebookAppId;
+            var facebookAppId = this.facebookAppId || this.getOgFbAppId();
 
             if (window.FB) {
                 return false;
             }
 
-            window.fbAsyncInit = function () {
-                FB.init({
-                    appId: facebookAppId,
-                    xfbml: true,
-                    version: 'v2.1'
-                });
-            };
+            if (facebookAppId) {
+                window.fbAsyncInit = function () {
+                    FB.init({
+                        appId: facebookAppId,
+                        xfbml: true,
+                        version: 'v2.1'
+                    });
+                };
+            }
 
             (function (d, s, id) {
                 var js, fjs = d.getElementsByTagName(s)[0];
@@ -406,6 +408,14 @@ function ShareBar(options) {
                 js.src = "//connect.facebook.net/en_US/sdk.js";
                 fjs.parentNode.insertBefore(js, fjs);
             }(document, 'script', 'facebook-jssdk'));
+        },
+
+        getOgFbAppId: function() {
+            var el = document.querySelector("meta[property='fb:app_id']")
+            if (el !== null) {
+                return el.getAttribute('content');
+            }
+            return;
         },
 
         createTwitterButton: function createTwitterButton(container, buttonClass) {

--- a/tests/share.spec.js
+++ b/tests/share.spec.js
@@ -81,6 +81,7 @@ describe('ShareBar - Setup Test Case', function () {
 
 describe('ShareBar - Methods Test Case', function () {
     'use strict';
+    var facebookAppId = "1234";
 
     beforeEach(function () {
         this.el = createShareContainer();
@@ -601,6 +602,60 @@ describe('ShareBar - Methods Test Case', function () {
                 name: 'Test title',
                 picture: 'http://g1.globo.com'
             });
+        });
+    });
+
+    describe('getFacebookUi', function() {
+        beforeEach(function(){
+            delete window.FB;
+            this.oldFacebookAppId = this.newBar.facebookAppId;
+        });
+
+        afterEach(function() {
+            this.newBar.facebookAppId = this.oldFacebookAppId;
+            delete window.FB;
+        });
+
+        it('should call pass facebookAppId to the FB SDK', function() {
+            this.newBar.facebookAppId = facebookAppId;
+            this.newBar.getFacebookUi();
+            window.FB = jasmine.createSpyObj('FB', ['init']);
+            window.fbAsyncInit();
+            expect(window.FB.init).toHaveBeenCalledWith(jasmine.objectContaining({appId: facebookAppId}));
+        });
+
+        it('should call getOgFbAppId when facebookAppId is not defined or empty', function(){
+            this.newBar.facebookAppId = '';
+            spyOn(this.newBar, 'getOgFbAppId').and.returnValue(facebookAppId);
+            this.newBar.getFacebookUi();
+            window.FB = jasmine.createSpyObj('FB', ['init']);
+            window.fbAsyncInit();
+            expect(window.FB.init).toHaveBeenCalledWith(jasmine.objectContaining({appId: facebookAppId}));
+        });
+
+        it('should not apply fbAsyncInit when facebookAppId not defined', function() {
+            delete window.fbAsyncInit;
+            this.newBar.facebookAppId = '';
+            spyOn(this.newBar, 'getOgFbAppId').and.returnValue('');
+            this.newBar.getFacebookUi();
+            expect(window['fbAsyncInit']).toBeUndefined();
+        });
+    });
+
+    describe('getOgFbAppId', function(){
+        it('should return the facebook app id from meta tag', function(){
+            var metaEl = document.createElement('META');
+            metaEl.setAttribute('property', 'fb:app_id');
+            metaEl.setAttribute('content', facebookAppId);
+            document.head.appendChild(metaEl);
+            var fbId = this.newBar.getOgFbAppId();
+            document.head.removeChild(metaEl);
+            expect(fbId).toEqual(facebookAppId);
+        });
+
+        it('should return null when element is not defined', function(){
+            var fbId = this.newBar.getOgFbAppId();
+            expect(fbId).toBeUndefined();
         });
     });
 


### PR DESCRIPTION
A [initialization](https://developers.facebook.com/docs/javascript/reference/v2.4#auth-methods) from Fb.init with a empty facebook App Id can affect any use from Facebook SDK on other places of a page. This merge checks if the parametrized fbId is falsy, not calling Fb.init on this case.
Also, the initialization process now is looking at the [Facebook Open Graph meta tag](https://developers.facebook.com/docs/sharing/webmasters#basic) for definition as fallback if the Facebook App Id is empty.