### PR TITLE
Fixing the include of facebook sdk script only when there is a valid Facebook app Id

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Para utilizar o share, basta inserir na página os arquivos JS e CSS e instancia
 </script>
 ```
 
-* É obrigatório passar a APP_ID do facebook se esta rede social estiver incluida na barra.
+* Caso não seja informado o APP_ID do facebook, o mesmo será obtido da página via [meta tag open graph](https://developers.facebook.com/docs/sharing/webmasters#basic) do facebook. Uma vez sem APP_ID, o share funcionará somente com a inicialização do facebook SDK através de outra barra com APP_ID na mesma página. De qualquer forma, é recomendado passar a APP_ID do facebook se esta rede social estiver incluida na barra.
 
 O elemento que deverá instanciar o share deverá seguir o exemplo abaixo
 ```

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Para utilizar o share, basta inserir na página os arquivos JS e CSS e instancia
 </script>
 ```
 
-* Caso não seja informado o APP_ID do facebook, o mesmo será obtido da página via [meta tag open graph](https://developers.facebook.com/docs/sharing/webmasters#basic) do facebook. Uma vez sem APP_ID, o share funcionará somente com a inicialização do facebook SDK através de outra barra com APP_ID na mesma página. De qualquer forma, é recomendado passar a APP_ID do facebook se esta rede social estiver incluida na barra.
+* Caso não seja informado o APP_ID do facebook, o mesmo será obtido da página via [meta tag open graph](https://developers.facebook.com/docs/sharing/webmasters#basic) do facebook. Uma vez sem APP_ID, o share funcionará somente com a inicialização de outra barra com APP_ID na mesma página. De qualquer forma, é recomendado passar a APP_ID do facebook se esta rede social estiver incluida na barra.
 
 O elemento que deverá instanciar o share deverá seguir o exemplo abaixo
 ```

--- a/src/js/share.js
+++ b/src/js/share.js
@@ -398,16 +398,16 @@ function ShareBar(options) {
                         version: 'v2.1'
                     });
                 };
+                (function (d, s, id) {
+                    var js, fjs = d.getElementsByTagName(s)[0];
+                    if (d.getElementById(id)) { return; }
+                    js = d.createElement(s);
+                    js.id = id;
+                    js.src = "//connect.facebook.net/en_US/sdk.js";
+                    fjs.parentNode.insertBefore(js, fjs);
+                }(document, 'script', 'facebook-jssdk'));
             }
 
-            (function (d, s, id) {
-                var js, fjs = d.getElementsByTagName(s)[0];
-                if (d.getElementById(id)) { return; }
-                js = d.createElement(s);
-                js.id = id;
-                js.src = "//connect.facebook.net/en_US/sdk.js";
-                fjs.parentNode.insertBefore(js, fjs);
-            }(document, 'script', 'facebook-jssdk'));
         },
 
         getOgFbAppId: function() {

--- a/tests/share.spec.js
+++ b/tests/share.spec.js
@@ -614,6 +614,8 @@ describe('ShareBar - Methods Test Case', function () {
         afterEach(function() {
             this.newBar.facebookAppId = this.oldFacebookAppId;
             delete window.FB;
+            var node = document.getElementById('facebook-jssdk');
+            if (node !== null) node.parentNode.removeChild(node);
         });
 
         it('should call pass facebookAppId to the FB SDK', function() {
@@ -639,6 +641,19 @@ describe('ShareBar - Methods Test Case', function () {
             spyOn(this.newBar, 'getOgFbAppId').and.returnValue('');
             this.newBar.getFacebookUi();
             expect(window['fbAsyncInit']).toBeUndefined();
+        });
+
+        it('should include the facebook script tag when facebookAppId is available', function() {
+            this.newBar.facebookAppId = facebookAppId;
+            this.newBar.getFacebookUi();
+            expect(document.getElementById('facebook-jssdk')).not.toBeNull(null);
+        });
+
+        it('should not include the facebook script tag when facebookAppId is empty', function() {
+            this.newBar.facebookAppId = '';
+            spyOn(this.newBar, 'getOgFbAppId').and.returnValue('');
+            this.newBar.getFacebookUi();
+            expect(document.getElementById('facebook-jssdk')).toBeNull();
         });
     });
 


### PR DESCRIPTION
This logic allows a next ShareBar on the page initialize the SDK properly, making facebook JS work even when a sharebar intialization don't specify a Facebook app Id.
This is a complement to the [last merge that I request](https://github.com/globocom/share-bar/pull/16).